### PR TITLE
Make the focused window always visible on the screen when moving it to a new created workspace

### DIFF
--- a/newworkspaceshortcut@barnix.io/extension.js
+++ b/newworkspaceshortcut@barnix.io/extension.js
@@ -33,13 +33,16 @@ function moveWindow(m) {
   //2. create  new  workspace
   Main.wm.insertWorkspace(newIndex);
 
-  //3. on the Focused Meta.Window object
-  myWin.change_workspace_by_index(newIndex, false);
+  //3. stick the focused/active window (the same as Always on Visible Workspace), so it can move to the new workspace and stay always visible on the screen when GNOME Shell plays workspace switch animation
+  myWin.stick();
 
   //4. move me to new workspace
   let myTime = global.get_current_time();
   let ws = global.workspaceManager.get_workspace_by_index(newIndex);
   ws.activate_with_focus(myWin, myTime);
+
+  //5. leave the just moved window in the new workspace
+  myWin.unstick();
 }
 
 // FUNCTION, create an empty workspace


### PR DESCRIPTION
In this extension using the "Move Window to New Workspace" shortcut creates a new workspace and teleports the active window into it. When GNOME Shell starts playing the workspace switch animation, the active window disappears from view. Then, the workspace switches to the new workspace to the window that had just been moved. Using the shortcut makes it look like the active window disappears and reappears on the screen.

GNOME Shell already has a built-in shortcut that moves a window to a workspace, and the window remains visible on the screen during the workspace switch animation. This PR references this GNOME Shell's built-in shortcut behavior to make this extension's window switching animation feel the same.

Instead of teleporting the focused/active window to a new created workspace it simply pins the window to all workspaces which makes it always visible on the screen when switching to other workspaces. Visually it looks the same as the official GNOME Shell's window moving to a workspace animation.